### PR TITLE
.setpath is subjective to a dev's JDK/JRE path. Should be ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.setpath


### PR DESCRIPTION
[//]: # (Credit: UCSD CSE 110 PR Template)
# Abstract
Added .gitignore file. Ignored .setpath since different dev's will have different JDK/JRE env paths.

# Issue
N/A

## Type of Change
- [ ] New Feature
- [ ] Continuing Feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Other (explain below)
Dev Story: Ensuring .setpath isnt added in the future

# Tests

# Pending Items
Is there any matter pending before PR can be merged?
